### PR TITLE
articles title and link should be unique for each user

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,7 +1,7 @@
 class Article < ApplicationRecord
   has_one :users, through: :accounts
-  validates :title, uniqueness: true, presence: true
-  validates :link, presence: true, uniqueness: true
+  validates :title, uniqueness: { scope: :user_id}, presence: true
+  validates :link, presence: true, uniqueness: { scope: :user_id}
   validates :avatar, presence: true
   validates :time, presence: true
   validates :user_id, presence: true


### PR DESCRIPTION
Previously articles could only be created if title and links were unique which is what we want but the problem arises when we create a new article for another user with the same title and link. The article wouldn't be created since it already found that this article existed for another user. So we needed it to be unique for the user that. is creating it.